### PR TITLE
fix: 对大数描述的修正

### DIFF
--- a/105.精读《What's new in javascript》.md
+++ b/105.精读《What's new in javascript》.md
@@ -90,10 +90,10 @@ nf.format(12345678901234567890n);
 
 记住 `Intl` 这个内置变量，后面还有不少国际化用途。
 
-同时，为了方便程序员阅读代码，大数还支持带下划线的书写方式：
+同时，为了方便程序员阅读代码，大数还支持带分隔符的书写方式，可以使用 `useGrouping` 属性配置，默认为 `true`:
 
 ```js
-const nf = new Intl.NumberFormat("fr");
+const nf = new Intl.NumberFormat("fr", { useGrouping: true });
 nf.format(12345678901234567890n);
 // -> '12 345 678 901 234 567 890'
 ```


### PR DESCRIPTION
查了下 api，没看到有提供带下划线的方式，我以为译者的意思是带分隔符。