### PR TITLE
fix:依赖取数

### DIFF
--- a/128.精读《Hooks 取数 - swr 源码》.md
+++ b/128.精读《Hooks 取数 - swr 源码》.md
@@ -448,8 +448,7 @@ useIsomorphicLayoutEffect(
 每次渲染的时候，SWR会试着执行`key`函数（例如 () => "/api/projects?uid=" + user.id)，如果这个函数抛出异常，那么就意味着它的依赖还没有就绪（user === undefined），SWR将暂停这个数据的请求。在任一数据完成加载时，由于`setState`触发重渲染，上述Hooks会被重选执行一遍（再次检查数据依赖是否就绪）然后对就绪的数据发起新的一轮请求。
 
 
-
-那么什么时候才轮到下次取数呢？这个时机是：
+另外对于一些正常请求碰到error（shouldRetryOnError默认为true）的情况下，下次取数的时机是：
 
 ```tsx
 const count = Math.min(opts.retryCount || 0, 8);

--- a/128.精读《Hooks 取数 - swr 源码》.md
+++ b/128.精读《Hooks 取数 - swr 源码》.md
@@ -408,7 +408,7 @@ return {
 
 ### 3.5 依赖的请求
 
-翻了一下代码，没有找到对循环依赖特别处理的逻辑，**后来看了官方文档才恍然大悟，原来是通过 `try/catch` + `onErrorRetry` 机制实现依赖取数的。**
+翻了一下代码，没有找到对循环依赖特别处理的逻辑，**后来看了官方文档才恍然大悟，原来是通过 `try/catch` 并巧妙结合React的UI=f(data) 机制实现依赖取数的。**
 
 看下面这段代码：
 
@@ -420,19 +420,34 @@ const { data: projects } = useSWR(() => "/api/projects?uid=" + user.id);
 怎么做到智能按依赖顺序请求呢？我们看 `useSWR` 取数函数的主体逻辑：
 
 ```tsx
-try {
-  // 设置 isValidation 为 true
-  // 取数、onSuccess 回调
-  // 设置 isValidation 为 false
-  // 设置缓存
-  // unstable_batchedUpdates
-} catch (err) {
-  // 撤销取数、缓存等对象
-  // 调用 onErrorRetry
-}
+const revalidate = useCallback(
+  async() => {
+    try {
+      // 设置 isValidation 为 true
+      // 取数、onSuccess 回调
+      // 设置 isValidation 为 false
+      // 设置缓存
+      // unstable_batchedUpdates
+    } catch (err) {
+      // 撤销取数、缓存等对象
+      // 调用 onError回调
+    }
+  },
+  [key]
+)
+
+useIsomorphicLayoutEffect(
+  ()=>{
+    ....
+  },
+  [key,revalidate,...]
+)
+
 ```
 
-可见取数逻辑被 `try` 住了，那么 `user.id` 在 `useSWR("/api/user")` 没有 Ready 的情况一定会抛出异常，则自动进入 `onErrorRetry` 逻辑，看看下次取数时 `user.id` 有没有 Ready。
+每次渲染的时候，SWR会试着执行`key`函数（例如 () => "/api/projects?uid=" + user.id)，如果这个函数抛出异常，那么就意味着它的依赖还没有就绪（user === undefined），SWR将暂停这个数据的请求。在任一数据完成加载时，由于`setState`触发重渲染，上述Hooks会被重选执行一遍（再次检查数据依赖是否就绪）然后对就绪的数据发起新的一轮请求。
+
+
 
 那么什么时候才轮到下次取数呢？这个时机是：
 


### PR DESCRIPTION
依赖取数执行中对于onErrorRetry的描述 时机是config里的shouldRetryOnError为true才会触发

